### PR TITLE
security: prevent reflected XSS in recherche.php error output

### DIFF
--- a/php/recherche.php
+++ b/php/recherche.php
@@ -94,7 +94,9 @@ echo "</body></html>";
 functions
 */
 function fehler($msg) {
- $ans = "<h4>$msg</h4>\n</body></html>\n";
+ // Escape: $msg may embed user input (e.g. the unknown dictionary code),
+ // which would otherwise be reflected XSS. All fehler messages are plain text.
+ $ans = "<h4>" . htmlspecialchars($msg, ENT_QUOTES) . "</h4>\n</body></html>\n";
  echo $ans;
  exit;
 }


### PR DESCRIPTION
## Reflected XSS via `dictionary` parameter

[`php/recherche.php`](https://github.com/sanskrit-lexicon/csl-santam/blob/master/php/recherche.php) reflects raw user input on the dictionary-not-found path:

```php
$dictionary = $_REQUEST['dictionary'];
...
fehler("No dictonary has been selected.$dictionary");   // $dictionary is raw

function fehler($msg) {
  $ans = "<h4>$msg</h4>\n...";   // echoed unescaped
  echo $ans; exit;
}
```

`sanitize_REQUEST_all()` does **not** actually sanitize — `filter_var($old, FILTER_UNSAFE_RAW)` is a no-op — so `?dictionary=<script>alert(1)</script>&st=x` is reflected verbatim and executes.

## Fix

Escape `$msg` inside `fehler()` with `htmlspecialchars($msg, ENT_QUOTES)`. Every `fehler()` message is plain text, so escaping in this one place neutralises the `$dictionary` reflection and the other error-message interpolations (`$line`, `$e`) too. `php -l` clean (PHP 8.2).

## ⚠️ Separate finding — SQL injection (not fixed in this PR)

The search terms are interpolated directly into the SQL string with no parameterization:

```php
$ans1 ="($lowdata $regexp '$wb$x$we')";   // $x = strtolower(user search term)
...
$befehl="select id,st,en from tamil where $where order by st collate nocase LIMIT $maxhits";
$file_db->query($sql);
```

A search term containing `'` (or `$maxhits` being non-numeric) breaks out of the query → **SQL injection**. The robust fix is PDO prepared statements (and an `intval($maxhits)`), which changes query construction and needs testing against the real `tamil.sqlite`; left for a focused follow-up rather than patched blind here.

Part of the org-wide reflected-XSS / JSONP sweep (sanskrit-lexicon/csl-websanlexicon#27, #63, #67).

🤖 Generated with [Claude Code](https://claude.com/claude-code)