### PR TITLE
security: fix SQL injection in recherche.php search (where1)

### DIFF
--- a/php/recherche.php
+++ b/php/recherche.php
@@ -177,7 +177,8 @@ function where1($var,$varname,$pr) {
  $lowdata = "lower($varname)";  //lower is sqlite function name
  for($ipart=0;$ipart < count($parts); $ipart++) {
   $part = $parts[$ipart];
-  $x = strtolower($part);  // 
+  // SQLi guard: $part is user input; escape ' for the SQLite string literal it is interpolated into below.
+  $x = str_replace("'", "''", strtolower($part));
   if ($pr == "exact") {
     $ans1 ="($lowdata $regexp '$wb$x$we')";
   } else if ($pr == "prefix") {


### PR DESCRIPTION
## What

Escapes the user search term before it is interpolated into the SQLite query in `php/recherche.php` `where1()`.

## Why

The search terms `st`/`en` (`$_REQUEST`) flow unsanitised into SQL string literals — `($lowdata regexp '\b$x\b')`, `($lowdata like '%$x%')` — and the query runs via `$file_db->query($sql)` (not a prepared statement). `sanitize_REQUEST_all()` uses `FILTER_UNSAFE_RAW`, which is a **no-op**, so a `'` in the term breaks out of the literal → SQL injection. (`$dictnum` is *not* affected — it comes from a trusted `books`-file lookup, not raw input.)

SQLite escapes a single quote as `''` (no backslash escaping), so `str_replace("'", "''", ...)` at the sink fully closes the literal-breakout. Normal Tamil/English search terms contain no quotes, so search behaviour is unchanged. A prepared-statement refactor of the WHERE builder would be the ideal follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)