### PR TITLE
security: cast $maxhits to int in LIMIT (second SQLi vector)

### DIFF
--- a/php/recherche.php
+++ b/php/recherche.php
@@ -41,7 +41,7 @@ if ($dbg) {
 $befehl="select id,st,en from tamil where $where order by st collate nocase";
 // put in LIMIT
 
-$befehl .= " LIMIT $maxhits";
+$befehl .= " LIMIT " . (int)$maxhits;  // SQLi guard: $maxhits is $_REQUEST input
 if ($dbg) {
  echo "befehl: $befehl<br>\n";
 }


### PR DESCRIPTION
## What

Casts `$maxhits` to `(int)` before it is interpolated into the SQL `LIMIT` clause in `php/recherche.php`.

## Why

Companion to #5. That PR closed the search-term injection in `where1()`, but `$maxhits = $_REQUEST['maxhits']` was still interpolated raw into `$befehl .= " LIMIT $maxhits"` and run via `$file_db->query()` — a second SQL-injection vector (`?maxhits=1 UNION SELECT ...`). `LIMIT` takes an integer, so `(int)` is the complete, behaviour-preserving fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)