### PR TITLE
security: preg_quote search term in regexp branches (ReDoS / regex injection)

### DIFF
--- a/php/recherche.php
+++ b/php/recherche.php
@@ -177,14 +177,20 @@ function where1($var,$varname,$pr) {
  $lowdata = "lower($varname)";  //lower is sqlite function name
  for($ipart=0;$ipart < count($parts); $ipart++) {
   $part = $parts[$ipart];
-  // SQLi guard: $part is user input; escape ' for the SQLite string literal it is interpolated into below.
-  $x = str_replace("'", "''", strtolower($part));
+  $part_l = strtolower($part);
+  // SQLi guard: escape ' for the SQLite string literal (the LIKE branch).
+  $x = str_replace("'", "''", $part_l);
+  // The regexp branches feed the value into _sqliteRegexp() -> preg_match() as a PCRE
+  // pattern, so the term must ALSO be preg_quote()d -- otherwise regex metacharacters
+  // inject and a term like "(a+)+" is a catastrophic-backtracking ReDoS (run per row).
+  // $wb/$we are the intended \b word-boundary anchors and are left active.
+  $xr = str_replace("'", "''", preg_quote($part_l, '/'));
   if ($pr == "exact") {
-    $ans1 ="($lowdata $regexp '$wb$x$we')";
+    $ans1 ="($lowdata $regexp '$wb$xr$we')";
   } else if ($pr == "prefix") {
-    $ans1 ="($lowdata $regexp '$wb$x')";
+    $ans1 ="($lowdata $regexp '$wb$xr')";
   } else if ($pr == "suffix") {
-    $ans1 ="($lowdata $regexp '$x$we')";
+    $ans1 ="($lowdata $regexp '$xr$we')";
   } else { // substring
     $ans1 ="($lowdata like '%$x%')";
   }


### PR DESCRIPTION
## What

Applies `preg_quote()` to the search term in `where1()`'s three `regexp` branches (`exact`/`prefix`/`suffix`).

## Why

Found by a code review of the SQLi fix (#5/#6). Those PRs made the term SQL-literal-safe (`'`->`''`), but the `regexp` branches feed the literal into the custom `_sqliteRegexp()` UDF, which runs `preg_match('/'.$pattern.'/i', $string)` — so the term also becomes a **PCRE pattern**. `'`->`''` does nothing to regex metacharacters, leaving:

- **ReDoS**: `?st=(a%2Ba)%2B&prst=exact` (`(a+)+`) → catastrophic backtracking, evaluated **once per result row** → CPU DoS.
- **Broken search / warnings**: an unbalanced term like `(` makes `preg_match` return `false` (treated as no-match) and emits a PHP warning.

`preg_quote($part, '/')` neutralises every metacharacter (and the `/` delimiter) while the intended `\b` anchors (`$wb`/`$we`) stay active; the result is still `'`->`''`-escaped for the SQL literal. The `LIKE` branch is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)